### PR TITLE
Update OOP.md

### DIFF
--- a/OOP.md
+++ b/OOP.md
@@ -131,7 +131,7 @@ Once shadowed, the only way to access the base member is to use the *hidden fiel
     type derived struct {
         base // embedding
         d int
-        a float32 //-SHADOWED
+        a float32 //-SHADOWS
     }
 
     func main() {


### PR DESCRIPTION
Based on the example in the main func, I think this was a typo and it meant to say SHADOWS because "derived.a" is shadowing "base.a", which is being shadowed. Hopefully this improves the readability because I had to re-read the example a few times to make sure I understood it.
