### PR TITLE
Add syntax highlighting to code blocks

### DIFF
--- a/Method Dispatch - Low Level Detail.md
+++ b/Method Dispatch - Low Level Detail.md
@@ -4,11 +4,13 @@
 
 A ***golang-Interface*** is ***a class with no fields and ONLY VIRTUAL methods***.
 
+```go
     type J interface 
        to-string() ( string )
        dosomea ( x, J )
        dosomeb ( x, k ) (J) 
        dosomec ( x, a string) ( int )
+```
 
 If a struct *implements* such methods, it “satisfies the interface”.
 
@@ -18,16 +20,20 @@ You can create a “var of type interface” or declare a function param of type
 
 so `var x J-interface` internally is:
 
+```go
     c-struct interface-var
 		ITable            *ITable
 		concrete-value    any_union
+```
 
 an ITable is:
-  
+
+```go
     c-struct ITable
            concrete-type  *type
        	   interface-type *interface
            jmp-table[]    *function
+```
 
       
 When a concrete type is assigned to a interface-var, golang *creates a jmp-method table on the fly (and caches it). There is a jmp-table for each combination of J-Interface \* concrete-type-implementing-J-interface
@@ -36,7 +42,9 @@ Let’s assume z is struct Z and there is a bunch of functions as *func dosomex 
 
 When you do:
 
+```go
      var x J-interface  = z
+ ```
 
 golang *constructs the ITable on the fly*. The J-interface has 4 methods, so it needs to calculate x.ITable. Golang will search the method “to-string” of struct Z and put it in ITable.jmp-table[0], then look for “dosomea (struct Z)” and put it in ITable.jmp-table[1] and so on. Then it will store ITable->concrete = &struct-Z, and X.itable->interface= &interface-J”.  
 
@@ -44,9 +52,11 @@ x, being an *interface* type, has two 32bit pointers, the first will point to th
 
 then…
 
+```go
     for n:=1; n++<100 {
          print( x.dosomea(x))
     }
+```
 
 the call *x.dosomea()* is: 
 * x is var type interface -> struct Z, Interface J

--- a/OOP.md
+++ b/OOP.md
@@ -46,12 +46,14 @@ func (r Rectangle) Area() float64 {
 
 This can be read as (pseudo code):
 
-    class Rectangle
-      field name: string
-      field Width: float64
-      field Height: float64
-      method Area() //non-virtual
-         return this.Width * this.Height
+```go
+class Rectangle
+  field Name: string
+  field Width: float64
+  field Height: float64
+  method Area() //non-virtual
+     return this.Width * this.Height
+```
 
 ###Constructor
 
@@ -61,28 +63,29 @@ This can be read as (pseudo code):
 
 pseudo-code for the generic constructor:
 
-        function construct ( class,  literal)
+```go
+function construct ( class,  literal)
 
-          helper function assignFields ( object, literal)  //recursive
-            if type-of object is "object"
-                if literal has field-names
-                    for each field in object.fields
-                        if literal has-field field.name
-                            assignFields(field.value,  literal.fields[field.name].value) //recurse
-                else
-                //literal without names, assign by position
-                    for n=0 to object.fields.length
-                        assignFields(object.fields[n].value,  literal.fields[n].value) //recurse
-            else
-                //atom type
-                set object.value = literal.value
+  helper function assignFields ( object, literal)  //recursive
+    if type-of object is "object"
+        if literal has field-names
+            for each field in object.fields
+                if literal has-field field.name
+                    assignFields(field.value,  literal.fields[field.name].value) //recurse
+        else
+        //literal without names, assign by position
+            for n=0 to object.fields.length
+                assignFields(object.fields[n].value,  literal.fields[n].value) //recurse
+    else
+        //atom type
+        set object.value = literal.value
 
 
-        // generic constructor main body
-        var classInstance = new class
-        assignFields(classInstance, literal)
-        return classInstance
-
+// generic constructor main body
+var classInstance = new class
+assignFields(classInstance, literal)
+return classInstance
+```
 
 Constructors example:
 
@@ -199,21 +202,22 @@ func main() {
 
 This can be read: (pseudo code)
 
-    class NamedObj
-       field Name: string
+```go
+class NamedObj
+   field Name: string
 
-    class Shape
-       inherits NamedObj
-       field color: int32
-       field isRegular: bool
+class Shape
+   inherits NamedObj
+   field color: int32
+   field isRegular: bool
 
-    class Rectangle
-       inherits NamedObj
-       inherits Shape
-       field center: Point
-       field Width: float64
-       field Height: float64
-
+class Rectangle
+   inherits NamedObj
+   inherits Shape
+   field center: Point
+   field Width: float64
+   field Height: float64
+```
 
 Example:
 
@@ -316,13 +320,13 @@ type Rectangle struct {
 
 //override method show
 func (r Rectangle) show() {
-	Println("Rectangle ", r.name) // "r" is "this"
+	Println("Rectangle ", r.Name) // "r" is "this"
 }
-
 ```
 
   Pseudo-code:
 
+```go
       class NamedObj
          Name: string
 
@@ -336,6 +340,7 @@ func (r Rectangle) show() {
 
          method show //override
            print "Rectangle", this.Name
+```
 
 Using it:
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@
 
 usage:
 
+```go
     import "flag"
     var int_ptr = flag.Int("flagname", 1234, "help message for flagname")
 
     package flag  
     func Int(name string, value int, usage string) *int
+```
    
 - because they make all the assignments at the flags.Parse() function.
 
@@ -41,6 +43,7 @@ An interface value is nil only if the inner value and type are both unset, (nil,
 
 This situation can be confusing, and often arises when a nil value is stored inside an interface value such as an error return:
 
+```go
     func returnsError() error {
     	var p *MyError = nil
     	if bad() {
@@ -48,8 +51,11 @@ This situation can be confusing, and often arises when a nil value is stored ins
     	}
     	return p // Will always return a non-nil error.
     }
+```
     
 If all goes well, the function returns a nil p, so the return value is an error interface value holding (*MyError, nil). This means that if the caller compares the returned error to nil, it will always look as if there was an error even if nothing bad happened. To return a proper nil error to the caller, the function must return an explicit nil:
+
+```go
 
     func returnsError() error {
     	if bad() {
@@ -57,6 +63,7 @@ If all goes well, the function returns a nil p, so the return value is an error 
     	}
     	return nil
     }
+```
     
 It's a good idea for functions that return errors always to use the error type in their signature (as we did above) rather than a concrete type such as *MyError, to help guarantee the error is created correctly. As an example, os.Open returns an error even though, if not nil, it's always of concrete type *os.PathError.
 

--- a/Type Switch Internals.md
+++ b/Type Switch Internals.md
@@ -6,6 +6,7 @@ you're defining and assigning the same var with different types on each case.
 
 Example from [go-wiki](https://code.google.com/p/go-wiki/wiki/Switch)
 
+```go
     func do(v interface{}) string {
             switch u := v.(type) {
             case int:
@@ -46,4 +47,5 @@ Example from [go-wiki](https://code.google.com/p/go-wiki/wiki/Switch)
                     return u.String() //call via method dispatch
             
        return "unknown"
+ ```
   

--- a/second-level methods.md
+++ b/second-level methods.md
@@ -8,6 +8,7 @@ A ***second-level method*** is a method which ***DO CALL *other methods* in the 
 
 Example, using structs-inheritance by embedding:
 
+```go
     package main
     
     import "fmt"
@@ -46,6 +47,7 @@ Example, using structs-inheritance by embedding:
     
     3 child simple called
     4 in complex, calling simple: parent simple called //2nd level method was called on base-class context
+```
      
 
 Here `func Simple` is a first-level method (do not call other struct methods)
@@ -56,6 +58,7 @@ Since all the inheritance hierarchy is made by embedding structs, the problem wi
 
 Now the example, but using interfaces:
 
+```go
     package main
     
     import "fmt"
@@ -100,6 +103,7 @@ Now the example, but using interfaces:
     2 in complex, calling simple:parent simple called
     3 child simple called
     4 in complex, calling simple:child simple called
+```
     
 Here `func Simple` is a first-level method (do not call other struct methods)
 and `func Complex` is a second-level method (do call other *interface* methods)


### PR DESCRIPTION
Technically... material tends to look a lil' bit better with some color in the mix.

Added `syntax highlighting` to doc - pseudo code included because it seems easier on the eyeballs.

Also managed to make the same fix as https://github.com/luciotato/golang-notes/pull/8 too

Great doc, looking forward to more :)
